### PR TITLE
A Mastodon plugin to extract a spot track image.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 			<artifactId>mastodon-tracking</artifactId>
 			<version>${mastodon-tracking.version}</version>
 		</dependency>
-
+		
 		<!-- Other deps -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -60,6 +60,17 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
 		
-		<mastodon.version>1.0.0-beta-19</mastodon.version>
+		<mastodon.version>1.0.0-beta-22-SNAPSHOT</mastodon.version>
 		<mastodon-tracking.version>1.0.0-beta-9</mastodon-tracking.version>
 		<bigdataviewer-core.version>10.2.0</bigdataviewer-core.version>
 		

--- a/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImagePanel.java
+++ b/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImagePanel.java
@@ -1,0 +1,263 @@
+/*-
+ * #%L
+ * mastodon-pasteur
+ * %%
+ * Copyright (C) 2019 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.spottrackimage;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JSeparator;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.mastodon.tracking.mamut.trackmate.wizard.util.SetupIDComboBox;
+
+import bdv.viewer.SourceAndConverter;
+
+public class SpotTrackImagePanel extends JPanel
+{
+	private static final long serialVersionUID = 1L;
+
+	private static final double STEP = 0.1;
+
+	private static final double MIN_SIZE = STEP;
+
+	private static final double MAX_SIZE = 10.;
+
+	private static final double DEFAULT_SIZE = 1.;
+
+	final JButton btnRun;
+
+	private SpinnerNumberModel spinnerModel;
+
+	private SetupIDComboBox cmbboxSource;
+
+	private JRadioButton rdbtn3D;
+
+	private JLabel lblLog;
+
+	public SpotTrackImagePanel( final List< SourceAndConverter< ? > > sources )
+	{
+		setBorder( new EmptyBorder( 5, 5, 5, 5 ) );
+		final Font bigFont = getFont().deriveFont( getFont().getSize2D() + 2f );
+
+		final BorderLayout borderLayout = new BorderLayout();
+		borderLayout.setVgap( 10 );
+		setLayout( borderLayout );
+
+		final JPanel panelControl = new JPanel();
+		add( panelControl, BorderLayout.SOUTH );
+		panelControl.setBorder( null );
+		final GridBagLayout layout = new GridBagLayout();
+		layout.rowWeights = new double[] { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
+		layout.rowHeights = new int[] { 24, 5, 5, 5, 0, 0 };
+		layout.columnWeights = new double[] { 0.0, 1.0, 0.0 };
+		layout.columnWidths = new int[] { 79, 50, 30 };
+		panelControl.setLayout( layout );
+
+		final GridBagConstraints gbcSeparator = new GridBagConstraints();
+		gbcSeparator.fill = GridBagConstraints.BOTH;
+		gbcSeparator.gridwidth = 3;
+		gbcSeparator.insets = new Insets( 5, 5, 5, 5 );
+		gbcSeparator.gridx = 0;
+		gbcSeparator.gridy = 0;
+		panelControl.add( new JSeparator(), gbcSeparator );
+
+		final JLabel lblSource = new JLabel( "With respect to source" );
+		lblSource.setFont( lblSource.getFont().deriveFont( lblSource.getFont().getSize() - 2f ) );
+		final GridBagConstraints gbcLblSource = new GridBagConstraints();
+		gbcLblSource.anchor = GridBagConstraints.EAST;
+		gbcLblSource.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblSource.gridx = 0;
+		gbcLblSource.gridy = 1;
+		panelControl.add( lblSource, gbcLblSource );
+
+		cmbboxSource = new SetupIDComboBox( sources );
+		cmbboxSource.setFont( cmbboxSource.getFont().deriveFont( cmbboxSource.getFont().getSize() - 2f ) );
+		final GridBagConstraints gbcCmbboxSource = new GridBagConstraints();
+		gbcCmbboxSource.gridwidth = 2;
+		gbcCmbboxSource.insets = new Insets( 5, 5, 5, 5 );
+		gbcCmbboxSource.fill = GridBagConstraints.HORIZONTAL;
+		gbcCmbboxSource.gridx = 1;
+		gbcCmbboxSource.gridy = 1;
+		panelControl.add( cmbboxSource, gbcCmbboxSource );
+
+		final JLabel lblSize = new JLabel( "Image Size (spot radius units)" );
+		lblSize.setFont( lblSize.getFont().deriveFont( lblSize.getFont().getSize() - 2f ) );
+		final GridBagConstraints gbcLblSize = new GridBagConstraints();
+		gbcLblSize.anchor = GridBagConstraints.EAST;
+		gbcLblSize.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblSize.gridx = 0;
+		gbcLblSize.gridy = 2;
+		panelControl.add( lblSize, gbcLblSize );
+
+		final int minSlider = 1;
+		final int maxSlider = 1 + ( int ) ( MAX_SIZE / STEP );
+		final int valueSlider = 1 + ( int ) ( DEFAULT_SIZE / STEP );
+		final JSlider sliderSize = new JSlider( minSlider, maxSlider, valueSlider );
+		final GridBagConstraints gbcSliderSize = new GridBagConstraints();
+		gbcSliderSize.fill = GridBagConstraints.HORIZONTAL;
+		gbcSliderSize.insets = new Insets( 5, 5, 5, 5 );
+		gbcSliderSize.gridx = 1;
+		gbcSliderSize.gridy = 2;
+		panelControl.add( sliderSize, gbcSliderSize );
+
+		spinnerModel = new SpinnerNumberModel( DEFAULT_SIZE, MIN_SIZE, MAX_SIZE, STEP );
+		final JSpinner spinnerSize = new JSpinner( spinnerModel );
+		spinnerSize.setFont( spinnerSize.getFont().deriveFont( spinnerSize.getFont().getSize() - 2f ) );
+		final GridBagConstraints gbcSpinnerSize = new GridBagConstraints();
+		gbcSpinnerSize.fill = GridBagConstraints.BOTH;
+		gbcSpinnerSize.insets = new Insets( 5, 5, 5, 5 );
+		gbcSpinnerSize.gridx = 2;
+		gbcSpinnerSize.gridy = 2;
+		panelControl.add( spinnerSize, gbcSpinnerSize );
+
+		final JPanel panel3D = new JPanel();
+		final GridBagConstraints gbcPanel3D = new GridBagConstraints();
+		gbcPanel3D.anchor = GridBagConstraints.EAST;
+		gbcPanel3D.gridwidth = 3;
+		gbcPanel3D.insets = new Insets( 5, 5, 5, 5 );
+		gbcPanel3D.fill = GridBagConstraints.VERTICAL;
+		gbcPanel3D.gridx = 0;
+		gbcPanel3D.gridy = 3;
+		panelControl.add( panel3D, gbcPanel3D );
+
+		final JRadioButton rdbtnCentralSlice = new JRadioButton( "Central slice", true );
+		rdbtnCentralSlice.setFont( rdbtnCentralSlice.getFont().deriveFont( rdbtnCentralSlice.getFont().getSize() - 2f ) );
+		rdbtn3D = new JRadioButton( "3D" );
+		rdbtn3D.setFont( rdbtn3D.getFont().deriveFont( rdbtn3D.getFont().getSize() - 2f ) );
+
+		panel3D.add( rdbtnCentralSlice );
+		panel3D.add( rdbtn3D );
+		final ButtonGroup btngrp = new ButtonGroup();
+		btngrp.add( rdbtn3D );
+		btngrp.add( rdbtnCentralSlice );
+
+		lblLog = new JLabel( " " );
+		lblLog.setFont( lblLog.getFont().deriveFont( lblLog.getFont().getStyle() | Font.ITALIC, lblLog.getFont().getSize() - 2f ) );
+		final GridBagConstraints gbcLblLog = new GridBagConstraints();
+		gbcLblLog.fill = GridBagConstraints.BOTH;
+		gbcLblLog.gridwidth = 3;
+		gbcLblLog.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblLog.gridx = 0;
+		gbcLblLog.gridy = 4;
+		panelControl.add( lblLog, gbcLblLog );
+
+		final JPanel panelButtonExport = new JPanel();
+		final GridBagConstraints gbcPanelButtonExport = new GridBagConstraints();
+		gbcPanelButtonExport.anchor = GridBagConstraints.EAST;
+		gbcPanelButtonExport.gridwidth = 3;
+		gbcPanelButtonExport.gridx = 0;
+		gbcPanelButtonExport.gridy = 5;
+		panelControl.add( panelButtonExport, gbcPanelButtonExport );
+		final FlowLayout flowLayout = ( FlowLayout ) panelButtonExport.getLayout();
+		flowLayout.setAlignment( FlowLayout.RIGHT );
+
+		btnRun = new JButton( "Run" );
+		panelButtonExport.add( btnRun );
+
+		final JPanel panelTitle = new JPanel();
+		add( panelTitle, BorderLayout.NORTH );
+		panelTitle.setLayout( new BorderLayout( 0, 5 ) );
+
+		final JLabel lblCsvImporter = new JLabel( "Spot-track Image", JLabel.CENTER );
+		lblCsvImporter.setFont( bigFont );
+		lblCsvImporter.setHorizontalAlignment( SwingConstants.CENTER );
+		panelTitle.add( lblCsvImporter, BorderLayout.NORTH );
+
+		final JLabel lblVersion = new JLabel( "<html>Create a time-lapse image centered on a spot along time in a track. Select one spot (all the track will be captured) or two connected spots (the path from the first to the last will be captured).</html>", JLabel.CENTER );
+		lblVersion.setFont( lblVersion.getFont().deriveFont( lblVersion.getFont().getStyle() | Font.ITALIC, lblVersion.getFont().getSize() - 2f ) );
+		panelTitle.add( lblVersion, BorderLayout.SOUTH );
+
+		// Listener stuff.
+		sliderSize.addChangeListener( new ChangeListener()
+		{
+
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final double val = MIN_SIZE + ( sliderSize.getValue() - 1 ) * STEP;
+				final double spinVal = ( ( Number ) spinnerModel.getValue() ).doubleValue();
+				if ( val == spinVal )
+					return;
+				spinnerModel.setValue( Double.valueOf( val ) );
+			}
+		} );
+		spinnerModel.addChangeListener( new ChangeListener()
+		{
+
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final double spinVal = ( ( Number ) spinnerModel.getValue() ).doubleValue();
+				final int intVal = ( int ) ( spinVal / STEP );
+				final int sliderVal = sliderSize.getValue();
+				if ( sliderVal == spinVal )
+					return;
+				
+				sliderSize.setValue( intVal );
+			}
+		} );
+	}
+
+	int getSelectedSetupID()
+	{
+		return cmbboxSource.getSelectedSetupID();
+	}
+
+	double getSizeFactor()
+	{
+		return ( ( Number ) spinnerModel.getValue() ).doubleValue();
+	}
+
+	boolean is3D()
+	{
+		return rdbtn3D.isSelected();
+	}
+
+	public Consumer< String > getLogger()
+	{
+		return msg -> lblLog.setText( msg );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImagePlugin.java
+++ b/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImagePlugin.java
@@ -1,0 +1,176 @@
+/*-
+ * #%L
+ * mastodon-pasteur
+ * %%
+ * Copyright (C) 2019 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.spottrackimage;
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.Image;
+import java.awt.event.ActionEvent;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JDialog;
+import javax.swing.WindowConstants;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.app.ui.ViewMenuBuilder.MenuItem;
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.MamutMenuBuilder;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.plugin.MamutPlugin;
+import org.mastodon.mamut.plugin.MamutPluginAppModel;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.views.bdv.SharedBigDataViewerData;
+import org.scijava.Context;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+import org.scijava.ui.behaviour.util.Actions;
+
+@Plugin( type = SpotTrackImagePlugin.class )
+public class SpotTrackImagePlugin implements MamutPlugin
+{
+
+	public static final String[] MENU_PATH = new String[] { "Plugins" };
+
+	public static final String SHOW_TRACK_IMAGE_DIALOG_ACTION = "show spot track image dialog";
+
+	private static final String[] ACTION_1_KEYS = new String[] { "not mapped" };
+
+	private static Map< String, String > menuTexts = new HashMap<>();
+
+	static
+	{
+		menuTexts.put( SHOW_TRACK_IMAGE_DIALOG_ACTION, "Track image" );
+	}
+
+	private final ToggleTrackImageDialogAction toggleDialog = new ToggleTrackImageDialogAction();
+
+	@Override
+	public Map< String, String > getMenuTexts()
+	{
+		return menuTexts;
+	}
+
+	@Override
+	public List< MenuItem > getMenuItems()
+	{
+		return Collections.singletonList( MamutMenuBuilder.makeFullMenuItem(
+				SHOW_TRACK_IMAGE_DIALOG_ACTION, MENU_PATH ) );
+	}
+
+	@Override
+	public void installGlobalActions( final Actions actions )
+	{
+		actions.namedAction( toggleDialog, ACTION_1_KEYS );
+	}
+
+	@Override
+	public void setAppPluginModel( final MamutPluginAppModel appModel )
+	{
+		if ( null == appModel || null == appModel.getAppModel() )
+			return;
+
+		toggleDialog.setAppModel( appModel );
+	}
+
+	/**
+	 * Command descriptions for all provided commands
+	 */
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigContexts.MASTODON );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( SHOW_TRACK_IMAGE_DIALOG_ACTION, ACTION_1_KEYS,
+					"Spot Track image: Extract an image centered on a spot over time." );
+		}
+	}
+
+	public static class ToggleTrackImageDialogAction extends AbstractNamedAction
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private JDialog trackImageDialog;
+
+		private SpotTrackImageUIController controller;
+
+		public ToggleTrackImageDialogAction()
+		{
+			super( SHOW_TRACK_IMAGE_DIALOG_ACTION );
+		}
+
+		public void setAppModel( final MamutPluginAppModel pluginModel )
+		{
+			final MamutAppModel appModel = pluginModel.getAppModel();
+			final Context context = pluginModel.getWindowManager().getContext();
+
+			final SharedBigDataViewerData bdvData = appModel.getSharedBdvData();
+			final Model model = appModel.getModel();
+			final SelectionModel< Spot, Link > selectionModel = appModel.getSelectionModel();
+
+			controller = new SpotTrackImageUIController(
+					bdvData,
+					model,
+					selectionModel,
+					context );
+			trackImageDialog = new JDialog( ( Frame ) null, "Track Image" );
+			trackImageDialog.setIconImages( Arrays.asList( new Image[] {
+					MastodonIcons.BVV_ICON_LARGE.getImage(),
+					MastodonIcons.BVV_ICON_MEDIUM.getImage(),
+					MastodonIcons.BVV_ICON_SMALL.getImage() } ) );
+			trackImageDialog.getContentPane().add( controller.getView(), BorderLayout.CENTER );
+			trackImageDialog.setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
+			trackImageDialog.setLocationRelativeTo( null );
+			trackImageDialog.setSize( 352, 320 );
+		}
+
+		@Override
+		public void actionPerformed( final ActionEvent e )
+		{
+			if ( null == trackImageDialog )
+				return;
+			trackImageDialog.setVisible( !trackImageDialog.isVisible() );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUIController.java
+++ b/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUIController.java
@@ -72,6 +72,7 @@ import net.imglib2.img.Img;
 import net.imglib2.img.ImgView;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
 public class SpotTrackImageUIController
@@ -196,6 +197,7 @@ public class SpotTrackImageUIController
 		return extract( sources, model, path, setupID, sizeFactor, is3d, logger );
 	}
 
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	public static ImgPlus< ? > extract(
 			final List< SourceAndConverter< ? > > sources,
 			final Model model,
@@ -243,10 +245,10 @@ public class SpotTrackImageUIController
 				: 1;
 
 		// Iterate over set to grab imglib image
-		final List< RandomAccessibleInterval< ? > > timepoints = new ArrayList<>( path.size() );
+		final List< RandomAccessibleInterval< RealType > > timepoints = new ArrayList<>( path.size() );
 		for ( final Spot spot : path )
 		{
-			final List< Img< ? > > channels = new ArrayList<>( sources.size() );
+			final List< Img< RealType > > channels = new ArrayList<>( sources.size() );
 
 			// Main transform and source.
 			final int frame = spot.getTimepoint();
@@ -266,7 +268,7 @@ public class SpotTrackImageUIController
 							mainTransform,
 							source,
 							frame );
-					channels.add( collect );
+					channels.add( ( Img< RealType > ) collect );
 				}
 				else
 				{
@@ -276,13 +278,13 @@ public class SpotTrackImageUIController
 							mainTransform,
 							source,
 							frame );
-					channels.add( collect );
+					channels.add( ( Img< RealType > ) collect );
 				}
 			}
 
 			if ( isMultiC )
 			{
-				final RandomAccessibleInterval< ? > multiChannel = Views.stack( channels );
+				final RandomAccessibleInterval< RealType > multiChannel = Views.stack( channels );
 				timepoints.add( multiChannel );
 			}
 			else
@@ -290,8 +292,7 @@ public class SpotTrackImageUIController
 				timepoints.add( channels.get( 0 ) );
 			}
 		}
-		@SuppressWarnings( "rawtypes" )
-		final RandomAccessibleInterval stack = Views.stack( timepoints );
+		final RandomAccessibleInterval< RealType > stack = Views.stack( timepoints );
 
 		// Add calibration and dimensionality.
 		int nDims = 3;
@@ -333,7 +334,6 @@ public class SpotTrackImageUIController
 			units[ id++ ] = "source";
 		units[ id++ ] = timeUnits;
 
-		@SuppressWarnings( { "rawtypes", "unchecked" } )
 		final ImgPlus< ? > imgplus = new ImgPlus( ImgView.wrap( stack ), name, axesType, cal, units );
 		return imgplus;
 	}

--- a/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUIController.java
+++ b/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUIController.java
@@ -1,0 +1,447 @@
+/*-
+ * #%L
+ * mastodon-pasteur
+ * %%
+ * Copyright (C) 2019 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.spottrackimage;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import javax.swing.JLabel;
+
+import org.mastodon.collection.RefList;
+import org.mastodon.graph.algorithm.ShortestPath;
+import org.mastodon.graph.algorithm.traversal.DepthFirstSearch;
+import org.mastodon.graph.algorithm.traversal.GraphSearch.SearchDirection;
+import org.mastodon.graph.algorithm.traversal.SearchListener;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.ui.util.EverythingDisablerAndReenabler;
+import org.mastodon.views.bdv.SharedBigDataViewerData;
+import org.scijava.Context;
+import org.scijava.display.DisplayService;
+
+import bdv.tools.brightness.ConverterSetup;
+import bdv.util.Affine3DHelpers;
+import bdv.viewer.ConverterSetups;
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import net.imagej.DefaultDataset;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imagej.display.DatasetView;
+import net.imagej.display.ImageDisplay;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.display.ColorTable8;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgView;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.view.Views;
+
+public class SpotTrackImageUIController
+{
+
+	private static final double EXTRA_BORDER = 0.5;
+
+	private final SpotTrackImagePanel view;
+
+	private final List< SourceAndConverter< ? > > sources;
+
+	private final Model model;
+
+	private final SelectionModel< Spot, Link > selectionModel;
+
+	private final Context context;
+
+	private final ConverterSetups converterSetups;
+
+	public SpotTrackImageUIController( final SharedBigDataViewerData bdvData, final Model model, final SelectionModel< Spot, Link > selectionModel, final Context context )
+	{
+		this.sources = bdvData.getSources();
+		this.model = model;
+		this.selectionModel = selectionModel;
+		this.converterSetups = bdvData.getConverterSetups();
+		this.context = context;
+		this.view = new SpotTrackImagePanel( sources );
+		view.btnRun.addActionListener( ( e ) -> run(
+				view.getSelectedSetupID(),
+				view.getSizeFactor(),
+				view.is3D(),
+				view.getLogger() ) );
+	}
+
+	public SpotTrackImagePanel getView()
+	{
+		return view;
+	}
+
+	private void run( final int setupID, final double sizeFactor, final boolean is3D, final Consumer< String > logger )
+	{
+		final EverythingDisablerAndReenabler enabler = new EverythingDisablerAndReenabler( view,
+				new Class[] { JLabel.class } );
+		enabler.disable();
+
+		new Thread( "Mastodon track image thread" )
+		{
+			@SuppressWarnings( "unchecked" )
+			@Override
+			public void run()
+			{
+				try
+				{
+					@SuppressWarnings( "rawtypes" )
+					final ImgPlus output = extract( sources, model, selectionModel, setupID, sizeFactor, is3D, logger );
+					if ( output != null )
+					{
+						final DefaultDataset dataset = new DefaultDataset( context, output );
+
+						final DisplayService displayService = context.getService( DisplayService.class );
+						final ImageDisplay display = ( ImageDisplay ) displayService.createDisplay( dataset );
+
+						final DatasetView view = ( DatasetView ) display.get( 0 );
+						for ( int c = 0; c < dataset.dimension( Axes.CHANNEL ); c++ )
+						{
+							final SourceAndConverter< ? > source = sources.get( c );
+							final ConverterSetup setup = converterSetups.getConverterSetup( source );
+							
+							// Set min & max display range.
+							final double min = setup.getDisplayRangeMin();
+							final double max = setup.getDisplayRangeMax();
+							output.setChannelMinimum( c, min );
+							output.setChannelMaximum( c, max );
+							view.setChannelRange( c, min, max );
+							
+							// Set LUT
+							final ARGBType color = setup.getColor();
+							final ColorTable8 colorTable = fromColor( new Color( color.get() ) );
+							view.setColorTable( colorTable, c );
+						}
+						display.update();
+					}
+				}
+				finally
+				{
+					enabler.reenable();
+				}
+			}
+		}.start();
+	}
+
+	public static ImgPlus< ? > extract(
+			final List< SourceAndConverter< ? > > sources,
+			final Model model,
+			final SelectionModel< Spot, Link > selectionModel,
+			final int setupID,
+			final double sizeFactor,
+			final boolean is3d,
+			final Consumer< String > logger )
+	{
+		logger.accept( "Capturing track image." );
+
+		final Spot[] spots = getRootAndLeaf( selectionModel, model.getGraph() );
+		if ( spots == null )
+		{
+			logger.accept( "<html>Expected 1 or 2 spots in the selection, got "
+					+ selectionModel.getSelectedVertices().size() + ". Aborting.</html>" );
+			return null;
+		}
+
+		final Spot root = spots[ 0 ];
+		final Spot leaf = spots[ 1 ];
+
+		// Build path.
+		final RefList< Spot > path = getPath( root, leaf, model.getGraph() );
+		if ( path == null )
+		{
+			logger.accept( "The two spots are not connected. Aborting." );
+			return null;
+		}
+
+		return extract( sources, model, path, setupID, sizeFactor, is3d, logger );
+	}
+
+	public static ImgPlus< ? > extract(
+			final List< SourceAndConverter< ? > > sources,
+			final Model model,
+			final RefList< Spot > path,
+			final int setupID,
+			final double sizeFactor,
+			final boolean is3d,
+			final Consumer< String > logger )
+	{
+		final boolean isMultiC = sources.size() > 1;
+
+		final String rootLbl = path.get( 0 ).getLabel();
+		final String leafLbl = path.get( path.size() - 1 ).getLabel();
+		logger.accept( "<html>Extracting track image from spot " + rootLbl
+				+ " to " + leafLbl + "</html>" );
+
+		// Build spot list & Get largest diameter
+		double maxRadiusSquared = Double.NEGATIVE_INFINITY;
+		int frameLargest = -1;
+		for ( final Spot spot : path )
+		{
+			final double radiusSquared = spot.getBoundingSphereRadiusSquared();
+			if ( radiusSquared > maxRadiusSquared )
+			{
+				maxRadiusSquared = radiusSquared;
+				frameLargest = spot.getTimepoint();
+			}
+		}
+		final double radius = Math.sqrt( maxRadiusSquared );
+
+		// Main source. Patch axes will correspond to main source axes.
+		final Source< ? > mainSource = sources.get( setupID ).getSpimSource();
+
+		// Get scale
+		final AffineTransform3D sourceToGlobal = new AffineTransform3D();
+		mainSource.getSourceTransform( frameLargest, 0, sourceToGlobal );
+		final double dx = Affine3DHelpers.extractScale( sourceToGlobal, 0 );
+		final double dy = Affine3DHelpers.extractScale( sourceToGlobal, 1 );
+		final double dz = Affine3DHelpers.extractScale( sourceToGlobal, 2 );
+
+		final int width = ( int ) Math.ceil( 2. * radius * ( sizeFactor + EXTRA_BORDER ) / dx );
+		final int height = ( int ) Math.ceil( 2 * radius * ( sizeFactor + EXTRA_BORDER ) / dy );
+		final int depth = is3d
+				? ( int ) Math.ceil( 2 * radius * ( sizeFactor + EXTRA_BORDER ) / dz )
+				: 1;
+
+		// Iterate over set to grab imglib image
+		final List< RandomAccessibleInterval< ? > > timepoints = new ArrayList<>( path.size() );
+		for ( final Spot spot : path )
+		{
+			final List< Img< ? > > channels = new ArrayList<>( sources.size() );
+
+			// Main transform and source.
+			final int frame = spot.getTimepoint();
+			final AffineTransform3D mainTransform = new AffineTransform3D();
+			mainSource.getSourceTransform( frame, 0, mainTransform );
+
+			// Collect patch for each source.
+			for ( final SourceAndConverter< ? > sac : sources )
+			{
+				final Source< ? > source = sac.getSpimSource();
+
+				if ( is3d )
+				{
+					final Interval patch = SpotTrackImageUtils.getIntervalAround( spot, width, height, depth, mainSource );
+					final Img< ? > collect = SpotTrackImageUtils.collectInterval(
+							patch,
+							mainTransform,
+							source,
+							frame );
+					channels.add( collect );
+				}
+				else
+				{
+					final Interval patch = SpotTrackImageUtils.getIntervalAround( spot, width, height, 0, mainSource );
+					final Img< ? > collect = SpotTrackImageUtils.collectInterval(
+							patch,
+							mainTransform,
+							source,
+							frame );
+					channels.add( collect );
+				}
+			}
+
+			if ( isMultiC )
+			{
+				final RandomAccessibleInterval< ? > multiChannel = Views.stack( channels );
+				timepoints.add( multiChannel );
+			}
+			else
+			{
+				timepoints.add( channels.get( 0 ) );
+			}
+		}
+		@SuppressWarnings( "rawtypes" )
+		final RandomAccessibleInterval stack = Views.stack( timepoints );
+
+		// Add calibration and dimensionality.
+		int nDims = 3;
+		if ( isMultiC )
+			nDims++;
+		if ( is3d )
+			nDims++;
+
+		final AxisType[] axesType = new AxisType[ nDims ];
+		int id = 0;
+		axesType[ id++ ] = Axes.X;
+		axesType[ id++ ] = Axes.Y;
+		if ( is3d )
+			axesType[ id++ ] = Axes.Z;
+		if ( isMultiC )
+			axesType[ id++ ] = Axes.CHANNEL;
+		axesType[ id++ ] = Axes.TIME;
+
+		final double[] cal = new double[ nDims ];
+		id = 0;
+		cal[ id++ ] = dx;
+		cal[ id++ ] = dy;
+		if ( is3d )
+			cal[ id++ ] = dz;
+		if ( isMultiC )
+			cal[ id++ ] = 1.;
+		cal[ id++ ] = 1.;
+
+		final String name = rootLbl + "→" + leafLbl;
+		final String spaceUnits = model.getSpaceUnits();
+		final String timeUnits = "link"; // not a true time.
+		final String[] units = new String[ nDims ];
+		id = 0;
+		units[ id++ ] = spaceUnits;
+		units[ id++ ] = spaceUnits;
+		if ( is3d )
+			units[ id++ ] = spaceUnits;
+		if ( isMultiC )
+			units[ id++ ] = "source";
+		units[ id++ ] = timeUnits;
+
+		@SuppressWarnings( { "rawtypes", "unchecked" } )
+		final ImgPlus< ? > imgplus = new ImgPlus( ImgView.wrap( stack ), name, axesType, cal, units );
+		return imgplus;
+	}
+
+	public static final Spot[] getRootAndLeaf( final SelectionModel< Spot, Link > selectionModel, final ModelGraph graph )
+	{
+
+		final Set< Spot > selection = selectionModel.getSelectedVertices();
+		final int nspots = selection.size();
+		if ( nspots < 1 || nspots > 2 )
+			return null;
+
+		final Spot root;
+		final Spot leaf;
+		if ( nspots == 1 )
+		{
+
+			final Spot spot = selection.iterator().next();
+			root = getRootOf( spot, graph );
+			leaf = getLeafOf( spot, graph );
+		}
+		else
+		{
+			final Spot spot1 = graph.vertexRef();
+			final Spot spot2 = graph.vertexRef();
+			final Iterator< Spot > it = selection.iterator();
+			spot1.refTo( it.next() );
+			spot2.refTo( it.next() );
+			if ( spot1.getTimepoint() < spot2.getTimepoint() )
+			{
+				root = spot1;
+				leaf = spot2;
+			}
+			else
+			{
+				root = spot2;
+				leaf = spot1;
+			}
+		}
+		return new Spot[] { root, leaf };
+	}
+
+	public static final RefList< Spot > getPath( final Spot root, final Spot leaf, final ModelGraph graph )
+	{
+		// Build path.
+		final ShortestPath< Spot, Link > pathFinder = new ShortestPath<>( graph, SearchDirection.DIRECTED );
+		final RefList< Spot > path = pathFinder.findPath( root, leaf );
+		if ( path == null )
+			return null;
+
+		path.sort( Comparator.comparing( s -> s.getTimepoint() ) );
+		return path;
+	}
+
+	private static Spot getRootOf( final Spot spot, final ModelGraph graph )
+	{
+		final Predicate< Spot > test = s -> s.incomingEdges().isEmpty();
+		return getOf( spot, graph, SearchDirection.REVERSED, test );
+	}
+
+	private static Spot getLeafOf( final Spot spot, final ModelGraph graph )
+	{
+		final Predicate< Spot > test = s -> s.outgoingEdges().isEmpty();
+		return getOf( spot, graph, SearchDirection.DIRECTED, test );
+	}
+
+	private static Spot getOf( final Spot spot, final ModelGraph graph, final SearchDirection direction, final Predicate< Spot > test )
+	{
+		final DepthFirstSearch< Spot, Link > search = new DepthFirstSearch<>( graph, direction );
+		final Spot target = graph.vertexRef();
+		search.setTraversalListener( new SearchListener< Spot, Link, DepthFirstSearch< Spot, Link > >()
+		{
+
+			@Override
+			public void processVertexLate( final Spot vertex, final DepthFirstSearch< Spot, Link > search )
+			{}
+
+			@Override
+			public void processVertexEarly( final Spot vertex, final DepthFirstSearch< Spot, Link > search )
+			{
+				if ( test.test( vertex ) )
+				{
+					target.refTo( vertex );
+					search.abort();
+				}
+			}
+
+			@Override
+			public void processEdge( final Link edge, final Spot from, final Spot to, final DepthFirstSearch< Spot, Link > search )
+			{}
+
+			@Override
+			public void crossComponent( final Spot from, final Spot to, final DepthFirstSearch< Spot, Link > search )
+			{}
+		} );
+		search.start( spot );
+		return target;
+	}
+
+	private static ColorTable8 fromColor( final Color color )
+	{
+		final byte[][] lut = new byte[ 3 ][ 256 ];
+		for ( int i = 0; i < 256; i++ )
+		{
+			lut[ 0 ][ i ] = ( byte ) ( ( double ) i * color.getRed() / 256. );
+			lut[ 1 ][ i ] = ( byte ) ( ( double ) i * color.getGreen() / 256. );
+			lut[ 2 ][ i ] = ( byte ) ( ( double ) i * color.getBlue() / 256. );
+		}
+		return new ColorTable8( lut );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUtils.java
+++ b/src/main/java/org/mastodon/mamut/spottrackimage/SpotTrackImageUtils.java
@@ -1,0 +1,191 @@
+package org.mastodon.mamut.spottrackimage;
+
+import org.mastodon.mamut.model.Spot;
+
+import bdv.viewer.Interpolation;
+import bdv.viewer.Source;
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.converter.TypeIdentity;
+import net.imglib2.display.projector.IterableIntervalProjector2D;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.position.transform.Round;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+public class SpotTrackImageUtils
+{
+
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	public static Img< ? > collectInterval(
+			final Interval patch,
+			final AffineTransform3D patchTransform,
+			final Source< ? > targetSource,
+			final int frame )
+	{
+		final AffineTransform3D targetToGlobal = new AffineTransform3D();
+		targetSource.getSourceTransform( frame, 0, targetToGlobal );
+
+		final AffineTransform3D t1 = targetToGlobal.inverse();
+		final AffineTransform3D t2 = t1.concatenate( patchTransform );
+		
+		// Squeeze singleton dimensions.
+		Interval intervalTarget = patch;
+		int d = 0;
+		do
+		{
+			if ( intervalTarget.dimension( d ) < 2 )
+				intervalTarget = Intervals.hyperSlice( intervalTarget, d );
+			else
+				d++;
+		}
+		while ( d < intervalTarget.numDimensions() );
+
+		// Create a target image with no singleton dimension.
+		final ImgFactory< ? > factory = Util.getArrayOrCellImgFactory( intervalTarget, ( NativeType ) targetSource.getType() );
+		final Img< ? > target = factory.create( intervalTarget );
+
+		final RealPoint targetPos = RealPoint.wrap( new double[ 3 ] );
+		final RealPoint sourcePos = RealPoint.wrap( new double[ 3 ] );
+
+		final RealRandomAccessible< ? > targetRai = targetSource.getInterpolatedSource( frame, 0, Interpolation.NEARESTNEIGHBOR );
+		final RealRandomAccess< ? > targetRa = targetRai.realRandomAccess();
+
+		final Cursor< ? > cursor = target.localizingCursor();
+		final long[] min = patch.minAsLongArray();
+		while ( cursor.hasNext() )
+		{
+			cursor.fwd();
+
+			sourcePos.setPosition( min );
+			for ( int d2 = 0; d2 < target.numDimensions(); d2++ )
+				sourcePos.move( cursor.getLongPosition( d2 ), d2 );
+
+			t2.apply( sourcePos, targetPos );
+			targetRa.setPosition( targetPos );
+			( ( Type ) cursor.get() ).set( ( Type ) targetRa.get() );
+		}
+		return target;
+	}
+
+	public static final Interval getIntervalAround( final Spot spot, final int width, final int height, final int depth, final Source< ? > source )
+	{
+		final int frame = spot.getTimepoint();
+		// Get spot coords
+		final AffineTransform3D sourceToGlobal = new AffineTransform3D();
+		source.getSourceTransform( frame, 0, sourceToGlobal );
+		final Point roundedSourcePos = new Point( 3 );
+		sourceToGlobal.applyInverse( new Round<>( roundedSourcePos ), spot );
+		final long x = roundedSourcePos.getLongPosition( 0 );
+		final long y = roundedSourcePos.getLongPosition( 1 );
+		final long z = roundedSourcePos.getLongPosition( 2 );
+		// Create interval.
+		final long[] min = new long[] { x - width / 2, y - height / 2, z - depth / 2 };
+		final long[] max = new long[] { x + width / 2, y + height / 2, z + depth / 2 };
+		return new FinalInterval( min, max );
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public static final Img< ? > getImgPatch( final Spot spot, final int width, final int height, final int depth, final Source source )
+	{
+		final int frame = spot.getTimepoint();
+		//Here be generics massacre...
+		final Type type = ( Type ) source.getType();
+		final RealType rtype = ( RealType ) type.createVariable();
+		rtype.setZero();
+		final NativeType ntype = ( NativeType ) rtype;
+		final long[] size = new long[] { width, height, depth };
+		final RandomAccessibleInterval img = source.getSource( frame, 0 );
+
+		// Crop
+		final Interval cropInterval = getIntervalAround( spot, width, height, depth, source );
+				//Intervals.createMinMax( x - xm, y - ym, z - zm, x + xp, y + yp, z + zp );
+
+		if ( isEmpty( cropInterval ) )
+		{
+			final Img ret = new ArrayImgFactory( ntype ).create( size );
+			return ret;
+		}
+
+		final ExtendedRandomAccessibleInterval extendZero = Views.extendZero( img );
+		final IntervalView crop = Views.zeroMin( Views.interval( extendZero, cropInterval ) );
+		final Img target = Util.getArrayOrCellImgFactory( crop, ntype ).create( size );
+
+		final RandomAccess randomAccess = crop.randomAccess();
+		final Cursor cursor = target.localizingCursor();
+		while ( cursor.hasNext() )
+		{
+			cursor.fwd();
+			randomAccess.setPosition( cursor );
+			( ( Type ) cursor.get() ).set( ( Type ) randomAccess.get() );
+		}
+		return target;
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public static final Img< ? > getImgPatch( final Spot spot, final int width, final int height, final Source source )
+	{
+		final int frame = spot.getTimepoint();
+
+		// Here be generics massacre...
+		final Type type = ( Type ) source.getType();
+		final RealType rtype = ( RealType ) type.createVariable();
+		rtype.setZero();
+		final NativeType ntype = ( NativeType ) rtype;
+		final RandomAccessibleInterval img = source.getSource( frame, 0 );
+
+		// Interval around spot.
+		final Interval cropInterval3D = getIntervalAround( spot, width, height, 0, source );
+		final long z = cropInterval3D.min( 2 );
+
+		// Keep only the 2D interval.
+		final FinalInterval cropInterval = Intervals.hyperSlice( cropInterval3D, 2 );
+
+		// Extract central slice
+		final IntervalView slice = Views.hyperSlice( img, 2, z );
+
+		// Crop
+		final long[] size = new long[] { width, height };
+		if ( isEmpty( cropInterval ) )
+		{
+			final Img ret = new ArrayImgFactory( ntype ).create( size );
+			return ret;
+		}
+
+		final ExtendedRandomAccessibleInterval extendZero = Views.extendZero( slice );
+		final IntervalView crop = Views.zeroMin( Views.interval( extendZero, cropInterval ) );
+		final Img target = Util.getArrayOrCellImgFactory( crop, ntype ).create( size );
+		new IterableIntervalProjector2D( 0, 1, crop, target, new TypeIdentity() ).map();
+		return target;
+	}
+
+	private static final boolean isEmpty( final Interval interval )
+	{
+		final int n = interval.numDimensions();
+		for ( int d = 0; d < n; ++d )
+			if ( interval.min( d ) > interval.max( d ) )
+				return true;
+		return false;
+	}
+
+	private SpotTrackImageUtils()
+	{}
+
+
+}

--- a/src/test/java/org/mastodon/mamut/io/csv/TestDrivePasteurPlugins.java
+++ b/src/test/java/org/mastodon/mamut/io/csv/TestDrivePasteurPlugins.java
@@ -38,21 +38,24 @@ import javax.swing.UnsupportedLookAndFeelException;
 import org.mastodon.mamut.MainWindow;
 import org.mastodon.mamut.WindowManager;
 import org.mastodon.mamut.project.MamutProjectIO;
-import org.scijava.Context;
 
 import mpicbg.spim.data.SpimDataException;
+import net.imagej.ImageJ;
 
 public class TestDrivePasteurPlugins
 {
 
 	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
 	{
+		final ImageJ ij = new ImageJ();
+		ij.launch( args );
+
 		Locale.setDefault( Locale.ROOT );
 		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
 
-		final WindowManager wm = new WindowManager( new Context() );
-//		final File targetFile = new File("samples/mamutproject-singlespot.mastodon");
-		final File targetFile = new File("samples/mamutproject.mastodon");
+		final WindowManager wm = new WindowManager( ij.context() );
+//		final File targetFile = new File( "samples/drosophila_crop.mastodon" );
+		final File targetFile = new File( "samples/mamutproject.mastodon" );
 		wm.getProjectManager().open( new MamutProjectIO().load( targetFile.getAbsolutePath() ) );
 		new MainWindow( wm ).setVisible( true );
 	}


### PR DESCRIPTION
This plugins generates an ImageJ2 image that follows a spot along a track.

It is similar to what we have in MaMuT and TrackMate under the name 'Extract track stack'. 
But it is somewhat extended to capture multiple views at the same time. 
It is easy for one view: you simply align the X, Y and Z axis of the output with the BDV Source axis. But if you want to capture also the other views, with a possible different registration, then you have to back transform this rectangle on the other sources. This plugin does that, the others don't.

Also it was 'fun' trying to copy the display range and display LUTs from BDV to ImageJ2.

![Screenshot 2021-11-04 at 16 39 51](https://user-images.githubusercontent.com/3583203/140363842-ee063d92-7f30-494b-8c64-f56ba5365522.png)

![Screenshot 2021-11-04 at 16 40 45](https://user-images.githubusercontent.com/3583203/140363899-74e1b1e4-afe1-452e-a9cd-38532823d317.png)

