### PR TITLE
Change menu path for Nearest Neighbor Statistics

### DIFF
--- a/src/main/java/org/mastodon/mamut/nearest/NearestObjectStatPlugin.java
+++ b/src/main/java/org/mastodon/mamut/nearest/NearestObjectStatPlugin.java
@@ -58,7 +58,7 @@ import bdv.ui.settings.style.StyleProfileManager;
 public class NearestObjectStatPlugin implements MamutPlugin
 {
 
-	public static final String[] MENU_PATH = new String[] { "Plugins" };
+	public static final String[] MENU_PATH = new String[] { "Plugins", "Compute Feature" };
 
 	public static final String SHOW_NEAREST_NEIGHBORS_STATS_DIALOG_ACTION = "generate statistics on nearest neighbors";
 
@@ -68,7 +68,7 @@ public class NearestObjectStatPlugin implements MamutPlugin
 
 	static
 	{
-		menuTexts.put( SHOW_NEAREST_NEIGHBORS_STATS_DIALOG_ACTION, "Generate statistics on nearest neighbors" );
+		menuTexts.put( SHOW_NEAREST_NEIGHBORS_STATS_DIALOG_ACTION, "Statistics on nearest neighbors" );
 	}
 
 	private final ShowDialogAction toggleDialog = new ShowDialogAction();


### PR DESCRIPTION
Since there are multiple plugins, currently Pasteur and Deep-Lineage, that add feature computations via the menu, it makes sense to arrange these computations under the same menu entry. If a user decided to install Mastodon with both extensions, the function would appear in the same sub-menu.

Even, if this is not the case, this change my make sense, since there might be further feature computing plugins in the future, even in the Pasteur extension.

Pasteur menu structure after the merge:

![grafik](https://github.com/mastodon-sc/mastodon-pasteur/assets/10515534/b313b8a1-0373-4de0-8e2f-137887da4343)

Current DeepLineage menu structure:

![grafik](https://github.com/mastodon-sc/mastodon-pasteur/assets/10515534/679547ad-d970-452e-9c47-c1ca1091eda1)


